### PR TITLE
feat: Extend features and behavior for Traversable objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,15 +135,18 @@ For convenience, you can access values specifically as numbers::
 
     >>> import jsane
 
-    >>> j = jsane.loads('{"numbers": {"one": 1}, "letters": {"zee": "Z"}}')
-    >>> +j.numbers.one
+    >>> j = jsane.loads('{"numbers": {"one": [1, "11"]}, "letter": "Z"}')
+    >>> +j.numbers.one[0]
     1
-    >>> +j.letters.zee, +j.numbers  # Things that aren't numbers are nan
+    >>> +j.letter, +j.numbers.one[1]  # Things that aren't numbers are nan
     (nan, nan)
     >>> +j.numbers
     nan
     >>> +j.what  # Things that don't exist are also nan.
     nan
+
+(NaN is not representable in JSON, so this should be enough for most use cases.
+Testing for NaN is also easy with the standard library math.isnan() function.)
 
 Likewise for strings, calling str() on a Traversable object is a simple
 shortcut::
@@ -152,12 +155,13 @@ shortcut::
     'Z'
     >>> str(j.numbers)
     "{'one': 1}"
-    >>> str(j.numbers.one)
+    >>> str(j.numbers.one[0])
     '1'
 
 In the same fashion, int() and float() are also shortcuts but unlike str()
 (and consistent with their behavior elsewhere in Python) they do not
-infallibly return objects of their respective type.
+infallibly return objects of their respective type (that is, they may raise a
+ValueError instead).
 
 "But how do I access a key called ``__call__``, or ``_obj`` where you store the
 wrapped object?!", I hear you ask. Worry not, object keys are still accessible

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Three-line intro
 
     >>> import jsane
     >>> j = jsane.loads('{"foo": {"bar": {"baz": ["well", "hello", "there"]}}}')
-    >>> j.foo.bar.baz[1].r()
+    >>> j.foo.bar.baz[1]()
     u'hello'
 
 
@@ -76,7 +76,7 @@ Motivation (non-infomercial version)
 ------------------------------------
 
 Okay seriously, ``this["thing"]["is"]["no"]["fun"]``. JSane lets you
-``traverse.json.like.this.r()``. That's it.
+``traverse.json.like.this()``. That's it.
 
 
 Usage
@@ -94,7 +94,7 @@ Here's an example of its usage::
     >>> import jsane
 
     >>> j = jsane.loads('{"some": {"json": [1, 2, 3]}}')
-    >>> j.some.json[2].r()
+    >>> j.some.json[2]()
     3
 
 You can also load an existing dictionary::
@@ -114,9 +114,9 @@ accesses::
     Traversable
 
 If you want your real object back at the end of the wild attribute ride, call
-``.r()``::
+it::
 
-    >>> j.foo.bar.r()
+    >>> j.foo.bar()
     {"baz": "yes!"}
 
 If an attribute, item or index along the way does not exist, you'll get an
@@ -128,17 +128,43 @@ exception. You can get rid of that by specifying a default::
     >>> j.haha_sucka_this_doesnt_exist.r(default="💩")
     "💩"
 
-"But how do I access a key called ``r``?!", I hear you ask. Worry not, I got you
-covered::
+For convenience, you can access values specifically as numbers::
 
-    >>> j.key["r"].more_key.r()
+    >>> import jsane
 
-Confused? Don't name your keys ``r``, then.
+    >>> j = jsane.loads('{"numbers": {"one": 1}, "letters": {"zee": "Z"}}')
+    >>> +j.numbers.one
+    1
+    >>> +j.letters.zee, +j.numbers  # Things that aren't numbers are nan
+    (nan, nan)
+    >>> +j.numbers
+    nan
+    >>> +j.what  # Things that don't exist are also nan.
+    nan
 
-That's about it. I'm not loving the ``r()`` API, so if anyone has any good
-recommendations on how I may better fulfil my unholy purpose, I'm changing it on
-the spot. No guarantees of stability before version 1, as always. Semver giveth,
-and semver taketh away.
+Likewise for strings, calling str() on a Traversable object is a simple
+shortcut::
+
+    >>> str(j.letters.zee)
+    'Z'
+    >>> str(j.numbers)
+    "{'one': 1}"
+    >>> str(j.numbers.one)
+    '1'
+
+In the same fashion, int() and float() are also shortcuts but unlike str()
+(and consistent with their behavior elsewhere in Python) they do not
+infallibly return objects of their respective type.
+
+"But how do I access a key called ``__call__``, or ``_obj`` where you store the
+wrapped object?!", I hear you ask. Worry not, I got you covered::
+
+    >>> j.key["__call__"].more_key()
+
+Confused? Don't name your keys after Python builtins, then.
+
+That's about it. No guarantees of stability before version 1, as always. Semver
+giveth, and semver taketh away.
 
 Help needed/welcome/etc, mostly with designing the API. Also, if you find this
 library useless, let me know.
@@ -168,6 +194,6 @@ FAQ
 
   Yes.
 
-* I hate the `.r()` thing, is there any way to avoid it?
+* All my JSON data uses '_obj' as keys!
 
-  Did you even **read** this README?
+  Come on, man. :(

--- a/jsane/__init__.py
+++ b/jsane/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 from .traversable import JSaneException
-from .wrapper import load, loads, dump, dumps, from_dict
+from .wrapper import load, loads, dump, dumps, from_dict, new
 
 __version__ = '0.1.0'

--- a/jsane/traversable.py
+++ b/jsane/traversable.py
@@ -1,8 +1,11 @@
+from numbers import Number
+
+
 # Use this as a detectable default value.
 DEFAULT = object()
 
 
-class JSaneException(Exception):
+class JSaneException(KeyError):
     pass
 
 
@@ -10,18 +13,48 @@ class Empty(object):
     def __init__(self, key_name=""):
         self._key_name = key_name
 
-    def __getattr__(self, key):
-        return self
+    def __getattr__(self, _):
+        return self  # Empty object returned should reflect the 1st failed key
     __getitem__ = __getattr__
 
-    def __repr__(self):
-        return "<Traversable key does not exist: %s>" % self._key_name
+    def __setattr__(self, key, value):
+        if key == '_key_name':
+            return object.__setattr__(self, '_key_name', value)
+        raise JSaneException("There is nothing here!")
 
-    def r(self, default=DEFAULT):
-        if default is DEFAULT:
-            raise JSaneException("Key does not exist: %s" % self._key_name)
-        else:
+    def __delattr__(self, key):
+        raise JSaneException("Key does not exist: %s" % (self._key_name,))
+    __delitem__ = __delattr__
+
+    def __eq__(self, other):
+        return False
+
+    def __repr__(self):
+        return "<Traversable key does not exist: %s>" % (self._key_name,)
+
+    def __call__(self, **kwargs):
+        # by using kwargs we ensure that usage of positional arguments, as if
+        # this object were another kind of function, will fail-fast and raise
+        # a TypeError
+        if 'default' in kwargs:
+            default = kwargs.pop('default')
+            if kwargs:
+                raise TypeError(
+                    "Unexpected argument: %s" % (next(iter(kwargs)),)
+                )
             return default
+        else:
+            raise JSaneException("Key does not exist: %s" % (self._key_name,))
+
+    def __pos__(self):
+        return float('nan')
+
+    def __str__(self):
+        raise JSaneException("Key does not exist: %s" % (self._key_name,))
+    __int__ = __float__ = __str__
+
+    def __contains__(self, _):
+        return False
 
 
 class Traversable(object):
@@ -35,20 +68,122 @@ class Traversable(object):
             return Empty(key)
     __getitem__ = __getattr__
 
+    def __setattr__(self, key, value):
+        if key == '_obj':
+            object.__setattr__(self, '_obj', value)
+            return
+        if isinstance(value, Traversable):
+            value = value._obj
+        # may cause TypeError; allow this to fall through
+        self._obj[key] = value
+
+    def __setitem__(self, key, value):
+        if isinstance(value, Traversable):
+            value = value._obj
+        # may cause TypeError; allow this to fall through
+        self._obj[key] = value
+
+    def __delattr__(self, key):
+        try:
+            del self._obj[key]
+        except KeyError:
+            raise JSaneException("Key does not exist: %s" % (key,))
+    __delitem__ = __delattr__
+
     def __eq__(self, other):
-        "Equality test."
-        if not hasattr(other, "_obj"):
-            return False
-        return self._obj == other._obj
+        """
+        Compare to other objects very reluctantly.
+
+        Only succeed when both objects are Traversable objects, and
+        fail otherwise (which defaults to returning False) to ensure
+        that the developer doesn't forget too easily what kind of
+        object they're actually using.
+        """
+        if isinstance(other, Traversable):
+            return self._obj == other._obj
+        else:
+            return NotImplemented
 
     def __repr__(self):
-        return "<Traversable: %r>" % self._obj
+        return "<Traversable: %r>" % (self._obj,)
 
-    def r(self, default=DEFAULT):
+    def __call__(self, **kwargs):
         """
         Resolve the object.
 
-        This will always succeed, since, if a lookup fails, an Empty instance
-        will be returned farther upstream.
+        This will always succeed, since, if a lookup fails, an Empty
+        instance will be returned farther upstream.
         """
+        # by using kwargs we ensure that usage of positional arguments, as if
+        # this object were another kind of function, will fail-fast and raise
+        # a TypeError
+        kwargs.pop('default', None)
+        if kwargs:
+            raise TypeError("Unexpected argument: %s" % (next(iter(kwargs)),))
         return self._obj
+
+    def __pos__(self):
+        """
+        Resolve the object as a number ONLY if it is a number.
+
+        Missing keys or non-numeric type will yield nan. Numeric
+        strings are not considered to be numbers under this
+        determination.
+        """
+        if isinstance(self._obj, Number):
+            return self._obj
+        else:
+            return float('nan')
+
+    def __str__(self):
+        """
+        Resolve the object and turn it into a string if it is not
+        already.
+
+        Essentially, str(traversable) is syntactic sugar for
+        str(traversable()).
+        """
+        return str(self._obj)
+
+    def __int__(self):
+        """
+        Resolve the object as an int if possible.
+
+        Essentially, int(traversable) is syntactic sugar for
+        int(traversable()).
+        """
+        return int(self._obj)
+
+    def __float__(self):
+        """
+        Resolve the object as a float if possible.
+
+        Essentially, float(traversable) is syntactic sugar for
+        float(traversable()).
+        """
+        return float(self._obj)
+
+    def __contains__(self, key):
+        """
+        Test for containment if the wrapped object is a list or dict.
+
+        Do not always check for containment whenever it supports the
+        operator, as this could result in some very sneaky bugs if a
+        key in the JSON is a string instead of a nested JSON object.
+        """
+        if isinstance(self._obj, (dict, list)):
+            return key in self._obj
+        else:
+            return False
+
+    def __dir__(self):
+        """
+        Return the attributes of this object.
+
+        Includes keys of the internal object if it's a dictionary.
+        Tremendously helpful for advanced interactive shell.
+        """
+        keys = dir(super(Traversable, self))
+        if isinstance(self._obj, dict):
+            keys += sorted(str(k) for k in self._obj)
+        return keys

--- a/jsane/traversable.py
+++ b/jsane/traversable.py
@@ -1,10 +1,6 @@
 from numbers import Number
 
 
-# Use this as a detectable default value.
-DEFAULT = object()
-
-
 class JSaneException(KeyError):
     pass
 

--- a/jsane/wrapper.py
+++ b/jsane/wrapper.py
@@ -13,13 +13,21 @@ def loads(*args, **kwargs):
     return Traversable(j)
 
 
-def dump(*args, **kwargs):
-    return json.dump(*args, **kwargs)
+def dump(obj, *args, **kwargs):
+    if isinstance(obj, Traversable):
+        obj = obj._obj
+    return json.dump(obj, *args, **kwargs)
 
 
-def dumps(*args, **kwargs):
-    return json.dumps(*args, **kwargs)
+def dumps(obj, *args, **kwargs):
+    if isinstance(obj, Traversable):
+        obj = obj._obj
+    return json.dumps(obj, *args, **kwargs)
 
 
 def from_dict(jdict):
     return Traversable(jdict)
+
+
+def new(kind=dict):
+    return Traversable(kind())

--- a/tests/test_jsane.py
+++ b/tests/test_jsane.py
@@ -87,9 +87,9 @@ class TestClass:
 
     def test_default(self):
         j = loads(self.json1)
-        assert j.key_1.key_2(None) is None
-        assert j.key_2.nonexistent[0]("default") == "default"
-        assert j.key_2.key_21[7]("default") == "default"
+        assert j.key_1.key_2(default=None) is None
+        assert j.key_2.nonexistent[0](default="default") == "default"
+        assert j.key_2.key_21[7](default="default") == "default"
         with pytest.raises(IndexError):
             j.key_2.key_24.key_244.key_2442[0](default="default")[7]
 

--- a/tests/test_jsane.py
+++ b/tests/test_jsane.py
@@ -6,7 +6,7 @@ import pep8
 
 sys.path.insert(0, os.path.abspath(__file__ + "/../.."))
 
-from jsane import loads, dumps, JSaneException, from_dict
+from jsane import loads, dumps, JSaneException, from_dict, new
 from jsane.traversable import Traversable
 
 
@@ -49,49 +49,129 @@ class TestClass:
                 "key_2442": ["ll1", "ll2"]
               }
             }
-          }
+          },
+          "numeric_string": "115",
+          "list": [1, 1, 2, 3, 5, 8]
         }
         """
         self.dict1 = {"foo": "bar"}
 
     def test_wrapper(self):
-        assert loads(dumps(self.dict1)).r() == self.dict1
+        assert loads(dumps(self.dict1))() == self.dict1
         assert json.dumps(self.dict1) == dumps(self.dict1)
-        assert self.dict1["foo"] == from_dict(self.dict1).foo.r()
+        assert self.dict1["foo"] == from_dict(self.dict1).foo()
         assert loads(dumps(self.dict1)), Traversable(self.dict1)
 
     def test_access(self):
         j = loads(self.json1)
-        assert j.key_1.r() == "value_1"
-        assert j["r"].r() == "yo"
-        assert j.key_2.key_21[1][1].r() == 2111
+        assert j.key_1() == "value_1"
+        assert j["r"]() == "yo"
+        assert j.key_2.key_21[1][1]() == 2111
 
     def test_exception(self):
         j = loads(self.json1)
         with pytest.raises(JSaneException):
-            j.key_2.nonexistent[0].r()
+            j.key_2.nonexistent[0]()
         with pytest.raises(JSaneException):
-            j.key_2.key_21[7].r()
+            j.key_2.key_21[7]()
         with pytest.raises(JSaneException):
-            j.key_1.key_2.r()
+            j.key_1.key_2()
         with pytest.raises(IndexError):
-            j.key_2.key_24.key_244.key_2442[0].r()[7]
+            j.key_2.key_24.key_244.key_2442[0]()[7]
         with pytest.raises(JSaneException):
-            j.key_2.key_24.key_244.key_2442[0][7].r()
+            j.key_2.key_24.key_244.key_2442[0][7]()
 
     def test_default(self):
         j = loads(self.json1)
-        assert j.key_1.key_2.r(None) is None
-        assert j.key_2.nonexistent[0].r("default") == "default"
-        assert j.key_2.key_21[7].r("default") == "default"
+        assert j.key_1.key_2(default=None) is None
+        assert j.key_2.nonexistent[0](default="default") == "default"
+        assert j.key_2.key_21[7](default="default") == "default"
         with pytest.raises(IndexError):
-            j.key_2.key_24.key_244.key_2442[0].r("default")[7]
+            j.key_2.key_24.key_244.key_2442[0](default="default")[7]
 
     def test_resolution(self):
         j = loads(self.json1)
-        assert j.key_2.key_21[0].r() == [2100, 2101]
-        assert j.key_2.key_21[0].r() == [2100, 2101]
-        assert j.key_2.key_24.key_244.key_2442[0].r()[0] == "l"
+        assert j.key_2.key_21[0]() == [2100, 2101]
+        assert j.key_2.key_21[0]() == [2100, 2101]
+        assert j.key_2.key_24.key_244.key_2442[0]()[0] == "l"
+
+    def test_numeric_resolution(self):
+        j = loads(self.json1)
+        assert +j.key_2.key_24.key_241 == 502
+        assert +j.key_2.key_24.key_242[1][0] == 7
+        assert +j.key_1 != +j.key_1  # inequality to oneself is the NaN test
+        assert +j.nonexistent != +j.nonexistent
+        assert +j.numeric_string != +j.numeric_string
+
+    def test_easy_casting(self):
+        j = loads(self.json1)
+        assert str(j.key_2.key_21[0]) == "[2100, 2101]"
+        assert str(j.numeric_string) == "115"
+        assert int(j.numeric_string) == 115
+        assert float(j.numeric_string) == 115.0
+        assert type(float(j.numeric_string)) is float
+        assert float(j.key_2.key_24.key_241) == 502
+        assert type(float(j.key_2.key_24.key_241)) is float
+        with pytest.raises(ValueError):
+            int(j.r)
+        with pytest.raises(ValueError):
+            float(j.r)
+
+    def test_dir(self):
+        j = loads(self.json1)
+        assert "numeric_string" in dir(j)
+        assert "key_22" in dir(j.key_2)
+
+    def test_contains(self):
+        j = loads(self.json1)
+        assert "numeric_string" in j
+        assert j.r() == "yo"
+        assert "y" not in j.r  # do not pass 'in' operator to strings
+        assert "y" in j.r()
+        assert "key_22" in j.key_2
+        assert "l1" in j.key_2.key_22  # do pass 'in' operator to lists
+        assert "nonexistent" not in j
+
+    def test_new(self):
+        assert new()() == {}
+        assert new(list)() == []
+
+    def test_setting(self):
+        j = loads(self.json1)
+        assert "nonexistent" not in j
+        j.nonexistent = 5
+        assert j.nonexistent() == 5
+        del j.nonexistent
+        assert "nonexistent" not in j
+        j.list = [5]
+        assert j.list[0]() == 5
+        j.list[0] = "six"
+        assert j.list[0]() == "six"
+
+    def test_deleting(self):
+        j = loads(self.json1)
+        assert "r" in j
+        del j.r
+        assert "r" not in j
+        assert j.list() == [1, 1, 2, 3, 5, 8]
+        del j.list[1:-1]
+        assert j.list() == [1, 8]
+
+    def test_equality_behavior(self):
+        i = loads('{"five": 5}')
+        f = loads('{"five": 5.0}')
+        assert i == f  # comparisons succeed between Traversable objects
+        assert i.five == f.five
+        assert i != {"five": 5}  # comparisons always return False otherwise
+        assert i.five != 5
+        assert i() == {"five": 5}
+        assert i.five() == 5  # once the value is out, comparison succeeds
+
+    def test_tuple_keys_fail_correctly(self):
+        # string formatting arguments needed to be wrapped in 1-tuples to avoid
+        # TypeError during string formatting when the key was a tuple
+        j = loads(self.json1)
+        j[:,:,:]
 
     def test_pep8(self):
         pep8style = pep8.StyleGuide([['statistics', True],


### PR DESCRIPTION
- resolve by calling the object
- resolve to a number using unary +
- 'in' operator to test if keys or items exist in wrapped dicts and lists
- better equality behavior
- shortcuts for str(), int(), and float()
- change and delete items in dictionaries and lists
- Empty objects now reflect only the first failed key in the traversal
- dumping Traversable objects dumps their wrapped object instead
- added new(), which by default creates a new jsane wrapper around a fresh empty dictionary
- dynamic keys from dir() function for interactive programming

BREAKING CHANGE: Wrapped values are no longer acquired by using .r(), but rather by calling as a function. Defaults now REQUIRE the named kwarg "default", which will not be accepted as a positional argument.
